### PR TITLE
Fix/google calendar sign in issue

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,6 +5,7 @@ import React, { useState, useCallback } from "react";
 import WidgetGrid, { Widget } from "./components/WidgetGrid.jsx";
 import useGoogleCalendarEvents from "./hooks/useGoogleCalendarEvents";
 import WeatherWidget from "./components/WeatherWidget.jsx"
+import CalendarWidget from "./components/CalendarWidget.jsx";
 
 export default function App() {
   const [widgets, setWidgets] = useState([
@@ -18,9 +19,6 @@ export default function App() {
       prev.map((w) => (w.id === id ? { ...w, col: pos.col, row: pos.row } : w))
     );
   }, []);
-
-  // Hook must be called at component top-level
-  const { events, loading, error, needsAuth, signIn } = useGoogleCalendarEvents();
 
   return (
     <div
@@ -51,28 +49,7 @@ export default function App() {
             >
               {w.id === "weather" && <WeatherWidget />}
 
-              {w.id === "calendar" && (
-                (loading)
-                  ? <div>Loading events...</div>
-                  : needsAuth
-                    ? (
-                      <div>
-                        <div style={{ marginBottom: 8 }}>Sign in to view your calendar events.</div>
-                        <button onClick={signIn} style={{ padding: '8px 12px', borderRadius: 6 }}>Sign in with Google</button>
-                      </div>
-                    )
-                    : error
-                      ? <div style={{ color: 'salmon' }}>Error: {error}</div>
-                      : (!events || events.length === 0)
-                        ? <div>No upcoming events</div>
-                        : (
-                          <ul style={{ margin: 0, paddingLeft: 16 }}>
-                            {events.map(ev => (
-                              <li key={ev.id}>{ev.summary || '(no title)'} ({ev.start?.dateTime?.slice(11,16) || ev.start?.date})</li>
-                            ))}
-                          </ul>
-                        )
-              )}
+              {w.id === "calendar" && <CalendarWidget /* maxResults={5} timeMin={new Date()} */ />}
 
               {w.id === "notes" && (
                 <div>

--- a/client/src/components/CalendarWidget.jsx
+++ b/client/src/components/CalendarWidget.jsx
@@ -3,8 +3,31 @@ import React from "react";
 import useGoogleCalendarEvents from "../hooks/useGoogleCalendarEvents";
 
 export default function CalendarWidget({ maxResults = 10, timeMin = new Date() }) {
-  const { events, loading, error, needsAuth, signIn } =
-    useGoogleCalendarEvents({ maxResults, timeMin });
+    const { events, loading, error, needsAuth, signIn } =
+        useGoogleCalendarEvents({ maxResults, timeMin });
+
+const formatStart = (ev) => {
+    const dt = ev.start?.dateTime;      // timed events
+    const d  = ev.start?.date;          // all-day events (YYYY-MM-DD)
+    if (dt) {
+        const date = new Date(dt);
+        return new Intl.DateTimeFormat(undefined, {
+            weekday: "short",
+            month: "short",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+        }).format(date);
+    }
+    if (d) {
+        return new Intl.DateTimeFormat(undefined, {
+            weekday: "short",
+            month: "short",
+            day: "numeric",
+        }).format(new Date(d + "T00:00:00"));
+    }
+    return "(no date)";
+  };
 
   if (loading) return <div>Loading events...</div>;
 
@@ -26,8 +49,7 @@ export default function CalendarWidget({ maxResults = 10, timeMin = new Date() }
     <ul style={{ margin: 0, paddingLeft: 16 }}>
       {events.map((ev) => (
         <li key={ev.id}>
-          {ev.summary || "(no title)"} (
-          {ev.start?.dateTime?.slice(11, 16) || ev.start?.date})
+          [{formatStart(ev)}] | {ev.summary || "(no title)"}
         </li>
       ))}
     </ul>

--- a/client/src/components/CalendarWidget.jsx
+++ b/client/src/components/CalendarWidget.jsx
@@ -1,0 +1,35 @@
+// components/CalendarWidget.jsx
+import React from "react";
+import useGoogleCalendarEvents from "../hooks/useGoogleCalendarEvents";
+
+export default function CalendarWidget({ maxResults = 10, timeMin = new Date() }) {
+  const { events, loading, error, needsAuth, signIn } =
+    useGoogleCalendarEvents({ maxResults, timeMin });
+
+  if (loading) return <div>Loading events...</div>;
+
+  if (needsAuth) {
+    return (
+      <div>
+        <div style={{ marginBottom: 8 }}>Sign in to view your calendar events.</div>
+        <button onClick={signIn} style={{ padding: "8px 12px", borderRadius: 6 }}>
+          Sign in with Google
+        </button>
+      </div>
+    );
+  }
+
+  if (error) return <div style={{ color: "salmon" }}>Error: {error}</div>;
+  if (!events || events.length === 0) return <div>No upcoming events</div>;
+
+  return (
+    <ul style={{ margin: 0, paddingLeft: 16 }}>
+      {events.map((ev) => (
+        <li key={ev.id}>
+          {ev.summary || "(no title)"} (
+          {ev.start?.dateTime?.slice(11, 16) || ev.start?.date})
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/client/src/hooks/useGoogleCalendarEvents.js
+++ b/client/src/hooks/useGoogleCalendarEvents.js
@@ -1,211 +1,260 @@
 import { useEffect, useState } from "react";
 
-// Google OAuth Client ID (from Google Cloud Console, Web App type)
+/**
+ * useGoogleCalendarEvents
+ * -----------------------
+ * Custom React hook that fetches a user's Google Calendar events (read-only)
+ * using Google Identity Services (GIS) for OAuth and the Calendar REST API.
+ *
+ * Returns:
+ *   { events, loading, error, needsAuth, signIn }
+ *     - events:   array of calendar event objects
+ *     - loading:  true while authenticating/fetching
+ *     - error:    string message if something went wrong
+ *     - needsAuth:true if user must click "Sign in" (silent auth failed)
+ *     - signIn(): triggers interactive OAuth popup and refetches events
+ */
+
+// Google OAuth Client ID (configure in Google Cloud Console → OAuth client (Web))
 const CLIENT_ID = "732897444427-h0p9benc1pvhg587fsmjjkco85kh4dkn.apps.googleusercontent.com";
-// Scope defines what level of access we want (read-only Calendar in this case)
+// Read-only Calendar scope (no write access)
 const SCOPES = "https://www.googleapis.com/auth/calendar.readonly";
 
-// Helper to dynamically load a script (Google Identity Services SDK)
+/**
+ * Dynamically load an external <script> and resolve when it's ready.
+ * Used to load the GIS SDK: https://accounts.google.com/gsi/client
+ */
 function loadScript(src) {
   return new Promise((resolve, reject) => {
-    // If script already exists, just resolve immediately
+    // If tag already present, don't add a second tag
     if (document.querySelector(`script[src="${src}"]`)) return resolve();
+
     const s = document.createElement('script');
     s.src = src;
     s.async = true;
-    s.onload = () => resolve();      // Resolve when loaded
-    s.onerror = (e) => reject(new Error('Failed to load ' + src));
-    document.head.appendChild(s);    // Add script tag to document
+    s.onload = () => resolve();      // script loaded successfully
+    s.onerror = (e) => reject(new Error('Failed to load ' + src));  // network/blocked/etc.
+    document.head.appendChild(s);
   });
 }
 
 export default function useGoogleCalendarEvents({ maxResults = 10, timeMin = new Date() } = {}) {
-  // React state hooks for events, loading state, errors, and auth prompt
-  const [events, setEvents] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [needsAuth, setNeedsAuth] = useState(false);
+    // UI state managed by the hook
+    const [events, setEvents] = useState([]);   // fetched event list
+    const [loading, setLoading] = useState(true);   // true while auth/fetch in flight
+    const [error, setError] = useState(null);   // human-readable error message
+    const [needsAuth, setNeedsAuth] = useState(false);  // show "Sign in" if silent auth fails
 
-  // Key used to save tokens in sessionStorage
-  const TOKEN_KEY = 'gcal_access_token';
+// Where we cache the access token in this browser tab
+    const TOKEN_KEY = 'gcal_access_token';
 
-  useEffect(() => {
-    let mounted = true; // flag to avoid updating state after unmount
+    useEffect(() => {
+        let mounted = true; // Prevent setState after unmount (avoids React warnings)
 
-    async function init() {
-      try {
-        // Load the Google Identity Services library
-        await loadScript('https://accounts.google.com/gsi/client');
+        // One-time initialization:
+        // 1) load GIS script
+        // 2) try cached token → else try silent auth
+        // 3) fetch events
+        async function init() {
+            try {
+            // 1) Ensure GIS SDK is loaded (defines window.google.accounts.oauth2)
+            await loadScript('https://accounts.google.com/gsi/client');
 
-        // Check if library is available
-        if (!window.google || !window.google.accounts || !window.google.accounts.oauth2) {
-          throw new Error('Google Identity Services not available');
-        }
+            // Check if library is available
+            if (!window.google || !window.google.accounts || !window.google.accounts.oauth2) {
+                throw new Error('Google Identity Services not available');
+            }
 
-        // Initialize a token client to request OAuth tokens
-        const tokenClient = window.google.accounts.oauth2.initTokenClient({
-          client_id: CLIENT_ID,
-          scope: SCOPES,
-        });
+            // Create a token client for requesting OAuth access tokens
+            const tokenClient = window.google.accounts.oauth2.initTokenClient({
+                client_id: CLIENT_ID,
+                scope: SCOPES,
+            });
 
         // Wrap token requests in a Promise for async/await use
-        const requestToken = (opts = {}) => new Promise((resolve, reject) => {
-          try {
-            tokenClient.callback = (resp) => {
-              if (resp && resp.access_token) resolve(resp); // success
-              else reject(resp || new Error('No token received'));
-            };
-            tokenClient.requestAccessToken(opts); // request token
-          } catch (e) { reject(e); }
-        });
+        const requestToken = (opts = {}) =>
+            new Promise((resolve, reject) => {
+            try {
+                tokenClient.callback = (resp) => {
+                    if (resp && resp.access_token) resolve(resp); // success path
+                    else reject(resp || new Error('No token received'));
+                };
+                tokenClient.requestAccessToken(opts); // triggers silent or interactive flow
+            } catch (e) {
+                reject(e);
+            }
+            });
 
-        // Try to use a saved token from sessionStorage if it’s still valid
+        // 2) Try to reuse a cached token if not expired (sessionStorage = per-tab)
         const saved = sessionStorage.getItem(TOKEN_KEY);
         let tokenResp = null;
         if (saved) {
-          try {
-            const parsed = JSON.parse(saved);
-            if (parsed.access_token && parsed.expires_at && parsed.expires_at > Date.now()) {
-              tokenResp = parsed; // reuse existing token
+            try {
+                const parsed = JSON.parse(saved);
+                if (parsed.access_token && parsed.expires_at && parsed.expires_at > Date.now()) {
+                    tokenResp = parsed; // reuse existing token
+                }
+            } catch (e) {
+                /* ignore parse errors */
             }
-          } catch (e) { /* ignore parse errors */ }
         }
 
-        // If no valid token, try silent login (prompt: 'none')
+        // If we don't have a valid token yet, attempt a silent token request (no popup).
+        // This works if the user previously consented on this origin.
         if (!tokenResp) {
-          try {
-            tokenResp = await requestToken({ prompt: 'none' });
-          } catch (e) {
-            // Silent login failed → need interactive sign-in
-            setNeedsAuth(true);
-            setLoading(false);
-            return;
-          }
+            try {
+                tokenResp = await requestToken({ prompt: 'none' });
+            } catch (e) {
+                // Silent auth failed (first visit, blocked cookies, no prior consent, etc.)
+                // Tell the UI to show the "Sign in" button and bail out early.
+                setNeedsAuth(true);
+                setLoading(false);
+                return;
+            }
         }
 
+        // 3) With a token, call the Calendar API for upcoming events
         if (!mounted) return;
         const accessToken = tokenResp.access_token;
         if (!accessToken) throw new Error('No access token returned');
 
-        // Build query parameters for the Calendar API request
+        // Build query parameters (expand recurring instances; sort by start time)
         const params = new URLSearchParams({
-          timeMin: new Date(timeMin).toISOString(),
-          singleEvents: 'true',
-          orderBy: 'startTime',
-          maxResults: String(maxResults),
+            timeMin: new Date(timeMin).toISOString(),
+            singleEvents: 'true',
+            orderBy: 'startTime',
+            maxResults: String(maxResults),
         });
 
         // Fetch events from the Google Calendar API
         const res = await fetch(
-          `https://www.googleapis.com/calendar/v3/calendars/primary/events?${params.toString()}`,
-          { headers: { Authorization: `Bearer ${accessToken}` } }
+            `https://www.googleapis.com/calendar/v3/calendars/primary/events?${params.toString()}`,
+            { headers: { Authorization: `Bearer ${accessToken}` } }
         );
 
-        // Handle errors from API
+        // Bubble up API errors with body text for easier debugging
         if (!res.ok) {
-          const body = await res.text();
-          throw new Error(`Calendar API error ${res.status}: ${body}`);
+            const body = await res.text();
+            throw new Error(`Calendar API error ${res.status}: ${body}`);
         }
 
-        // Parse response JSON and update state
+        // Update UI with events (or [] if none)
         const data = await res.json();
         if (!mounted) return;
         setEvents(data.items || []);
 
-        // Save token back to sessionStorage with expiry
+        // Refresh cache with (approximate) expiry time so future runs can reuse
         try {
-          const expiresIn = tokenResp.expires_in || tokenResp.expiresAt || null;
-          const expiresAt = expiresIn ? Date.now() + (expiresIn * 1000) : Date.now() + (60 * 60 * 1000);
-          sessionStorage.setItem(TOKEN_KEY, JSON.stringify({
-            access_token: accessToken,
-            expires_at: expiresAt
-          }));
-        } catch (e) { /* ignore storage errors */ }
+            const expiresIn = tokenResp.expires_in || tokenResp.expiresAt || null;
+            const expiresAt = expiresIn ? Date.now() + (expiresIn * 1000) : Date.now() + (60 * 60 * 1000);
+            sessionStorage.setItem(TOKEN_KEY, JSON.stringify({
+                access_token: accessToken,
+                expires_at: expiresAt
+            }));
+        } catch (e) {
+            /* ignore storage errors */
+        }
       } catch (e) {
         if (!mounted) return;
         // Normalize error into readable string
         let msg;
         try {
-          if (e instanceof Error) msg = e.message;
-          else if (typeof e === 'string') msg = e;
-          else msg = JSON.stringify(e);
-        } catch (err) { msg = String(e); }
+            if (e instanceof Error) msg = e.message;
+            else if (typeof e === 'string') msg = e;
+            else msg = JSON.stringify(e);
+        } catch (err) {
+            msg = String(e);
+        }
         setError(msg || 'Unknown error');
       } finally {
         if (mounted) setLoading(false);
       }
     }
 
+    // start init on mount (and when inputs change)
     init();
-    return () => { mounted = false; }; // cleanup
-  }, [maxResults, timeMin]);
 
-  // Function to trigger interactive sign-in
+    // Cleanup on unmount — stops any late setState
+    return () => {
+        mounted = false;
+    };
+  }, [maxResults, timeMin]);    // re-fetch if query window/limit changes
+
+  /**
+     * Trigger an interactive sign-in (popup). Use when needsAuth === true.
+     * On success, caches the token and immediately refetches events.
+     */
   const signIn = async () => {
     // setLoading(true);
     // setError(null);
     try {
-      // Ensure script is loaded
-      if (!window.google || !window.google.accounts || !window.google.accounts.oauth2) {
-        await loadScript('https://accounts.google.com/gsi/client');
-      }
+        // Ensure the GIS SDK is available (in case user clicked quickly)
+        if (!window.google || !window.google.accounts || !window.google.accounts.oauth2) {
+            await loadScript('https://accounts.google.com/gsi/client');
+        }
 
-      // Create token client for interactive sign-in
-      const tokenClient = window.google.accounts.oauth2.initTokenClient({
-        client_id: CLIENT_ID,
-        scope: SCOPES
-      });
-
-      const requestToken = (opts = {}) => new Promise((resolve, reject) => {
-        try {
-          tokenClient.callback = (resp) => {
-            if (resp && resp.access_token) resolve(resp);
-            else reject(resp || new Error('No token'));
-          };
-          tokenClient.requestAccessToken(opts);
-        } catch (e) { reject(e); }
-      });
-
-      // This time we allow prompting → will show Google login UI
-      const tokenResp = await requestToken({ prompt: '' });
-      if (!tokenResp || !tokenResp.access_token) throw new Error('Sign-in failed');
-
-      // Save token and expiry
-      const expiresIn = tokenResp.expires_in || null;
-      const expiresAt = expiresIn ? Date.now() + (expiresIn * 1000) : Date.now() + (60*60*1000);
-      sessionStorage.setItem(TOKEN_KEY, JSON.stringify({
-        access_token: tokenResp.access_token,
-        expires_at: expiresAt
-      }));
-
-      setNeedsAuth(false);
-
-      // Immediately fetch events again
-      try {
-        const params = new URLSearchParams({
-          timeMin: new Date(timeMin).toISOString(),
-          singleEvents: 'true',
-          orderBy: 'startTime',
-          maxResults: String(maxResults)
+        // Interactive token client (allows Google UI)
+        const tokenClient = window.google.accounts.oauth2.initTokenClient({
+            client_id: CLIENT_ID,
+            scope: SCOPES
         });
+
+        // Same Promise adapter as above
+        const requestToken = (opts = {}) =>
+            new Promise((resolve, reject) => {
+                try {
+                    tokenClient.callback = (resp) => {
+                    if (resp && resp.access_token) resolve(resp);
+                    else reject(resp || new Error('No token'));
+                };
+                tokenClient.requestAccessToken(opts);   // with prompt → popup allowed
+            } catch (e) {
+                reject(e);
+            }
+        });
+
+        // Allow prompting by passing empty prompt string
+        const tokenResp = await requestToken({ prompt: '' });
+        if (!tokenResp || !tokenResp.access_token) throw new Error('Sign-in failed');
+
+        // Persist token so subsequent API calls (this tab) don't reprompt
+        const expiresIn = tokenResp.expires_in || null;
+        const expiresAt = expiresIn ? Date.now() + (expiresIn * 1000) : Date.now() + (60*60*1000);
+        sessionStorage.setItem(TOKEN_KEY, JSON.stringify({
+            access_token: tokenResp.access_token,
+            expires_at: expiresAt
+        }));
+
+        setNeedsAuth(false);
+        setLoading(true);
+
+        // Immediately fetch events again
+        try {
+        const params = new URLSearchParams({
+            timeMin: new Date(timeMin).toISOString(),
+            singleEvents: 'true',
+            orderBy: 'startTime',
+            maxResults: String(maxResults)
+        });
+
         const res = await fetch(
-          `https://www.googleapis.com/calendar/v3/calendars/primary/events?${params.toString()}`,
-          { headers: { Authorization: `Bearer ${tokenResp.access_token}` } }
+            `https://www.googleapis.com/calendar/v3/calendars/primary/events?${params.toString()}`,
+            { headers: { Authorization: `Bearer ${tokenResp.access_token}` } }
         );
         if (!res.ok) throw new Error('Calendar fetch failed: ' + res.status);
+
         const data = await res.json();
         setEvents(data.items || []);
-      } catch (e) {
-        setError(e.message || String(e));
-      }
-    } catch (e) {
-      setError(e.message || String(e));
-    } finally {
-      setLoading(false);
-    }
-  };
+        } catch (e) {
+            setError(e.message || String(e));
+        }
+        } catch (e) {
+            setError(e.message || String(e));
+        } finally {
+            setLoading(false);
+        }
+    };
 
-  // Hook returns events, loading status, error messages,
-  // whether user needs to sign in, and a signIn() function
-  return { events, loading, error, needsAuth, signIn };
+    // Expose hook values & actions to the component using it
+    return { events, loading, error, needsAuth, signIn };
 }

--- a/client/src/hooks/useGoogleCalendarEvents.js
+++ b/client/src/hooks/useGoogleCalendarEvents.js
@@ -185,8 +185,7 @@ export default function useGoogleCalendarEvents({ maxResults = 10, timeMin = new
      * On success, caches the token and immediately refetches events.
      */
   const signIn = async () => {
-    // setLoading(true);
-    // setError(null);
+
     try {
         // Ensure the GIS SDK is available (in case user clicked quickly)
         if (!window.google || !window.google.accounts || !window.google.accounts.oauth2) {

--- a/client/src/hooks/useGoogleCalendarEvents.js
+++ b/client/src/hooks/useGoogleCalendarEvents.js
@@ -142,8 +142,8 @@ export default function useGoogleCalendarEvents({ maxResults = 10, timeMin = new
 
   // Function to trigger interactive sign-in
   const signIn = async () => {
-    setLoading(true);
-    setError(null);
+    // setLoading(true);
+    // setError(null);
     try {
       // Ensure script is loaded
       if (!window.google || !window.google.accounts || !window.google.accounts.oauth2) {


### PR DESCRIPTION
# Summary  
Disable automatic Google sign-in on app load and require an explicit user action to start OAuth.  
The hook no longer attempts a silent token request (`prompt: 'none'`) when there is no valid cached token, instead it sets [`needsAuth = true`] so the UI shows the Sign in button.  When the widget is moved, the silents token request isn't prompt

---

# Related Issues  
#32 

---

# Changes Introduced  
- **[`useGoogleCalendarEvents.js`]**  
  - Removed the silent token request path.  
  - When no valid cached token exists, the hook bails and sets [`needsAuth = true`], requiring explicit sign-in.  
  - Preserved interactive [`signIn()`] behavior and token caching.  

**Branch:** `fix/googleCalendar_SignIn_Issue`  

---

# Testing Performed  

### Manual (instructions to reproduce)  
1. Start the client dev server.  
2. Open the app in a browser
3. Confirm that no automatic Google sign-in popup appears on load and the Calendar widget shows a Sign in button.  
4. Move the widget around and the there are no Google sign-in pop up appearing.

---

# Checklist  
- The sign in pop up isn't appearing when widget is moved.
